### PR TITLE
docs: fix fano amplitude docstring, list missing exports, fix scratch script

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.os == 'ubuntu-latest' && matrix.version == '1'
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         if: matrix.os == 'ubuntu-latest' && matrix.version == '1'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All model functions follow the CurveFit.jl convention: `fn(parameters, x)` where
 
 ## Available Models
 
-**Lineshapes**: `gaussian`, `lorentzian`, `pseudo_voigt`, `power_law`, `logistic`, `gaussian2d`
+**Lineshapes**: `gaussian`, `lorentzian`, `voigt`, `pseudo_voigt`, `fano`, `log_normal`, `power_law`, `logistic`, `gaussian2d`
 
 **Temporal**: `single_exponential`, `stretched_exponential`, `n_exponentials`, `sine`, `damped_sine`
 

--- a/src/lineshapes.jl
+++ b/src/lineshapes.jl
@@ -362,7 +362,8 @@ Fano lineshape for asymmetric resonance profiles.
 
 # Arguments
 - `p`: Parameters `[A, x₀, Γ, q]` or `[A, x₀, Γ, q, y₀]`
-  - `A`: Amplitude
+  - `A`: Scale factor — *not* the peak height. The value at `x₀` is `A·q²` and the
+    profile maximum is `A·(1 + q²)`.
   - `x₀`: Center position
   - `Γ`: Width parameter
   - `q`: Fano asymmetry parameter (|q| → ∞ recovers Lorentzian)


### PR DESCRIPTION
Part of the post-refactor full-stack consistency pass (read-only multi-agent audit → 67 confirmed findings). Full test suite green locally. Details in the commit body.